### PR TITLE
Add ' ° ' symbol to text variable

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -118,7 +118,7 @@ fn main() {
         .find(|(code, _)| *code == weather_code.parse::<i32>().unwrap())
         .map(|(_, symbol)| symbol)
         .unwrap();
-    let text = format!("{} {}", weather_icon, indicator);
+    let text = format!("{} {}°", weather_icon, indicator);
     data.insert("text", text);
 
     let mut tooltip = format!(


### PR DESCRIPTION
I don't know if the symbol was intentionally left out, but I felt that it was missing. If this was intentional, please feel free to ignore this completely

Thanks for creating this module :)