### PR TITLE
Added Russian Language to lang.rs

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -118,7 +118,7 @@ impl Lang {
             Self::EN => "Wind".to_string(),
             Self::DE => "Wind".to_string(),
             Self::PL => "Wiatr".to_string(),
-            Self::RU => "Ветренно".to_string(),
+            Self::RU => "Ветер".to_string(),
         }
     }
 }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -5,6 +5,7 @@ pub enum Lang {
     EN,
     DE,
     PL,
+    RU,
 }
 
 impl Lang {
@@ -13,13 +14,15 @@ impl Lang {
             Self::EN => "wttr.in".to_string(),
             Self::DE => "de.wttr.in".to_string(),
             Self::PL => "pl.wttr.in".to_string(),
+            Self::RU => "ru.wttr.in".to_string(),
         }
     }
     pub fn feels_like(&self) -> String {
         match &self {
             Self::EN => "Feels Like".to_string(),
             Self::DE => "Gefühlt wie".to_string(),
-            Lang::PL => "Temperatura odczuwalna".to_string(),
+            Self::PL => "Temperatura odczuwalna".to_string(),
+            Self::RU => "Ощущается как".to_string(),
         }
     }
     pub fn humidity(&self) -> String {
@@ -27,6 +30,7 @@ impl Lang {
             Self::EN => "humidity".to_string(),
             Self::DE => "Luftfeuchtigkeit".to_string(),
             Self::PL => "Wilgotność".to_string(),
+            Self::RU => "Влажность".to_string(),
         }
     }
     pub fn location(&self) -> String {
@@ -34,6 +38,7 @@ impl Lang {
             Self::EN => "Location".to_string(),
             Self::DE => "Standort".to_string(),
             Self::PL => "Lokalizacja".to_string(),
+            Self::RU => "Местоположение".to_string(),
         }
     }
     pub fn today(&self) -> String {
@@ -41,6 +46,7 @@ impl Lang {
             Self::EN => "Today".to_string(),
             Self::DE => "Heute".to_string(),
             Self::PL => "Dzisiaj".to_string(),
+            Self::RU => "Сегодня".to_string(),
         }
     }
     pub fn tomorrow(&self) -> String {
@@ -48,6 +54,7 @@ impl Lang {
             Self::EN => "Tomorrow".to_string(),
             Self::DE => "Morgen".to_string(),
             Self::PL => "Jutro".to_string(),
+            Self::RU => "Завтра".to_string(),
         }
     }
     pub fn fog(&self) -> String {
@@ -55,6 +62,7 @@ impl Lang {
             Self::EN => "Fog".to_string(),
             Self::DE => "Nebel".to_string(),
             Self::PL => "Mgła".to_string(),
+            Self::RU => "Туман".to_string(),
         }
     }
     pub fn frost(&self) -> String {
@@ -62,6 +70,7 @@ impl Lang {
             Self::EN => "Frost".to_string(),
             Self::DE => "Frost".to_string(),
             Self::PL => "Mróz".to_string(),
+            Self::RU => "Мороз".to_string(),
         }
     }
     pub fn overcast(&self) -> String {
@@ -69,6 +78,7 @@ impl Lang {
             Self::EN => "Overcast".to_string(),
             Self::DE => "Bewölkung".to_string(),
             Self::PL => "Zachmurzenie".to_string(),
+            Self::RU => "Пасмурно".to_string(),
         }
     }
     pub fn rain(&self) -> String {
@@ -76,6 +86,7 @@ impl Lang {
             Self::EN => "Rain".to_string(),
             Self::DE => "Regen".to_string(),
             Self::PL => "Deszcz".to_string(),
+            Self::RU => "Дождь".to_string(),
         }
     }
     pub fn snow(&self) -> String {
@@ -83,6 +94,7 @@ impl Lang {
             Self::EN => "Snow".to_string(),
             Self::DE => "Schnee".to_string(),
             Self::PL => "Śnieg".to_string(),
+            Self::RU => "Снег".to_string(),
         }
     }
     pub fn sunshine(&self) -> String {
@@ -90,6 +102,7 @@ impl Lang {
             Self::EN => "Sunshine".to_string(),
             Self::DE => "Sonnenschein".to_string(),
             Self::PL => "Słonecznie".to_string(),
+            Self::RU => "Солнечно".to_string(),
         }
     }
     pub fn thunder(&self) -> String {
@@ -97,6 +110,7 @@ impl Lang {
             Self::EN => "Thunder".to_string(),
             Self::DE => "Donner".to_string(),
             Self::PL => "Burza".to_string(),
+            Self::RU => "Гроза".to_string(),
         }
     }
     pub fn wind(&self) -> String {
@@ -104,6 +118,7 @@ impl Lang {
             Self::EN => "Wind".to_string(),
             Self::DE => "Wind".to_string(),
             Self::PL => "Wiatr".to_string(),
+            Self::RU => "Ветренно".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,8 @@ fn main() {
     );
     tooltip += &format!("{}: {}°\n", lang.feels_like(), feels_like);
     tooltip += &format!(
-        "Wind: {}Km/h\n",
+        "{}: {}Km/h\n",
+        lang.wind(),
         current_condition["windspeedKmph"].as_str().unwrap()
     );
     tooltip += &format!(


### PR DESCRIPTION
I'm actually not familiar with Rust. But i would like to contribute to translate it to Russian.
I've checked if  'http://ru.wttr.in/'  exists. It does but translated partially. So anyway it would be readable. 
P.S. Somewhy wttr_in_subdomain had 
`Lang::PL`
instead of 
`Self::PL`
as it does other options, i changed it, hope it's okay.