### PR TITLE
add space in between the time and am/pm

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -15,7 +15,7 @@ pub fn format_time(time: &str, ampm: bool) -> String {
         } else {
             hour % 12
         };
-        format!("{: <4}", format!("{}{}", hour12, am_or_pm))
+        format!("{: <4}", format!("{} {}", hour12, am_or_pm))
     } else {
         format!("{:02}", hour)
     }


### PR DESCRIPTION
this extra space makes it have a cleaner look in the tooltip