### PR TITLE
Show nighttime icons before sunrise and after sunset.

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -124,5 +124,68 @@ pub const WEATHER_CODES_NERD: &[(i32, &str)] = &[
     (431, "󰖗"),
 ];
 
+pub const WEATHER_CODES_NIGHT_NERD: &[(i32, &str)] = &[
+    (113, "󰖔"), // Sunny -> Moon and stars
+    (116, "󰼱"), // Partly cloudly -> Moon clouds
+    (119, "󰼱"), // Cloudy ->Moon clouds
+    (122, "󰖐"), // Very cloudy
+    (143, "󰖑"), // Fog
+    (176, "󰖗"), // Light showers
+    (179, "󰙿"), // Light sleet showers
+    (182, "󰙿"), // Light sleet
+    (185, "󰙿"), // Light sleet
+    (200, "󰙾"), // Thundery showers
+    (227, "󰖘"), // Light snow
+    (230, "󰼶"), // Heavy snow
+    (248, "󰖑"), // Fog
+    (260, "󰖑"), // Fog
+    (263, "󰖗"), // Light showers
+    (266, "󰖗"), // Light rain
+    (281, "󰙿"), // Light sleet
+    (284, "󰙿"), // Light sleet
+    (293, "󰖗"), // Light rain
+    (296, "󰖗"), // Light rain
+    (299, "󰖖"), // Heavy showers
+    (302, "󰖖"), // Heavy rain
+    (305, "󰖖"), // Heavy showers
+    (308, "󰖖"), // Heavy rain
+    (311, "󰙿"), // Light sleet
+    (314, "󰙿"), // Light sleet
+    (317, "󰙿"), // Light sleet
+    (320, "󰖘"), // Light snow
+    (323, "󰖘"), // Light snow showers
+    (326, "󰖘"), // Light snow showers
+    (329, "󰼶"), // Heavy Snow
+    (332, "󰼶"), // Heavy Snow
+    (335, "󰼶"), // Heavy snow showers
+    (338, "󰼶"), // Heavy snow
+    (350, "󰙿"), // Light sleet
+    (353, "󰖗"), // Light showers
+    (356, "󰖖"), // Heavy showers
+    (359, "󰖖"), // Heavy rain
+    (362, "󰙿"), // Light sleet showers
+    (365, "󰙿"), // Light sleet showers
+    (368, "󰖘"), // Light snow showers
+    (371, "󰼶"), // Heavy snow showers
+    (374, "󰙿"), // Light sleet showers
+    (377, "󰙿"), // Light sleet
+    (386, "󰙾"), // Thundery showers
+    (389, "󰙾"), // Thundery heavy rain
+    (392, "󰙾"), // Thundery snow showers
+    (395, "󰼶"), // Heavy snow showers
+    (398, "󰖗"), // This is all the ones defined in the wttr.in source code, not sure what these are, but apparently some sort of rain.
+    (401, "󰖗"),
+    (404, "󰖗"),
+    (407, "󰖗"),
+    (410, "󰖗"),
+    (413, "󰖗"),
+    (416, "󰖗"),
+    (419, "󰖗"),
+    (422, "󰖗"),
+    (425, "󰖗"),
+    (428, "󰖗"),
+    (431, "󰖗"),
+];
+
 
 pub const ICON_PLACEHOLDER: &str = "{ICON}";

--- a/src/format.rs
+++ b/src/format.rs
@@ -5,6 +5,16 @@ use std::collections::HashMap;
 use crate::lang::Lang;
 use crate::ICON_PLACEHOLDER;
 
+pub fn extract_hour_time(hour: &serde_json::Value) -> NaiveTime {
+    let hour_int = hour.as_str().unwrap().parse::<u32>().unwrap() / 100;
+
+    let hour_time = NaiveTime::parse_from_str(
+        format!("{}:00", &hour_int).as_str(),
+        "%k:%M"
+    ).unwrap();
+    return hour_time
+}
+
 pub fn format_time(time: &str, ampm: bool) -> String {
     let hour = time.replace("00", "").parse::<i32>().unwrap();
 
@@ -58,16 +68,19 @@ pub fn format_chances(hour: &serde_json::Value, lang: &Lang) -> String {
         .join(", ")
 }
 
-pub fn format_ampm_time(day: &serde_json::Value, key: &str, ampm: bool) -> String {
+pub fn extract_day_data(day: &serde_json::Value, key: &str) -> NaiveTime {
+    NaiveTime::parse_from_str(day["astronomy"][0][key].as_str().unwrap(), "%I:%M %p")
+        .unwrap()
+}
+
+pub fn format_ampm_time(time: NaiveTime, ampm: bool) -> String {
     if ampm {
-        day["astronomy"][0][key].as_str().unwrap().to_string()
+        time.format("%I:%M %p").to_string()
     } else {
-        NaiveTime::parse_from_str(day["astronomy"][0][key].as_str().unwrap(), "%I:%M %p")
-            .unwrap()
-            .format("%H:%M")
-            .to_string()
+        time.format("%H:%M").to_string()
     }
 }
+
 pub fn format_indicator(
     weather_conditions: &Value,
     area: &Value,

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,9 +253,9 @@ fn main() {
             let hour_naive_time = NaiveTime::parse_from_str(format!("{}:00", &formatted_hour_time).as_str(), "%k:%M").unwrap();
             let is_day = sunrise <= hour_naive_time && sunset > hour_naive_time;
 
+            // If today only print out most recent hr to end of day
             if i == 0
-                && now.hour() >= 2
-                && formatted_hour_time.parse::<u32>().unwrap() < now.hour() - 2
+                && formatted_hour_time.parse::<i32>().unwrap() < now.hour() as i32 - 2
             {
                 continue;
             }


### PR DESCRIPTION
Hi, thanks for this project. I have been using your python gist for a while and wondered about adding "nighttime" icons before sunrise and after sunset. I found it is now a Rust code and better packaged/distributed so thought I would implement this and see if it is of interest.

This PR is what I have on my current version to achieve this.

- Adds a set of `WEATHER_CODES_NIGHT_NERD` as a counterpart to the current daytime codes.
- Calculates `is_day` boolean based on current or hourly time compared to sunrise and sunset times for that day.
- To achieve the `is_day` comparison I refactored the time processing/formatting slightly to provide `NaiveTime`s in `main`. The formatting and final output should be unchanged, however.

Queries:

- Happy to add further "night" icons as appropriate.
- Addition of unicode night icons.
  I have issues rendering these on my system so use nerd fonts instead, but if you can point me at the relevant icons I will and add them in to the unicode.
- Repeated icons.
  Currently `WEATHER_CODES_NIGHT_NERD` contains a lot of repetition for a couple of icon changes. It is not clear how to simplify this without refactoring.
- This is currently enforced behaviour. I can look at making it controlled by a runtime arg if you prefer.
- Currently the "hourly" times are compared to sunrise/sunset as this is easiest.\
  It could be adjusted to use the "midpoint" of the time band or "nearest boundary" with additional logic to better reflect whether most of a 3hr slot is day/night.

If this feature is of interest I'm happy to discuss and make adjustments as you wish

![shot](https://github.com/user-attachments/assets/65669b9f-5141-4512-babf-4388a9a3abbf)