### PR TITLE
Show moon phases in the tooltip

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,7 +24,7 @@ pub const WEATHER_CODES: &[(i32, &str)] = &[
     (305, "🌧️"), // Heavy showers
     (308, "🌧️"), // Heavy rain
     (311, "🌧️"), // Light sleet
-    (314, "🌧️"), // Light sleet 
+    (314, "🌧️"), // Light sleet
     (317, "🌧️"), // Light sleet
     (320, "🌨️"), // Light snow
     (323, "🌨️"), // Light snow showers
@@ -87,7 +87,7 @@ pub const WEATHER_CODES_NERD: &[(i32, &str)] = &[
     (305, "󰖖"), // Heavy showers
     (308, "󰖖"), // Heavy rain
     (311, "󰙿"), // Light sleet
-    (314, "󰙿"), // Light sleet 
+    (314, "󰙿"), // Light sleet
     (317, "󰙿"), // Light sleet
     (320, "󰖘"), // Light snow
     (323, "󰖘"), // Light snow showers
@@ -124,5 +124,26 @@ pub const WEATHER_CODES_NERD: &[(i32, &str)] = &[
     (431, "󰖗"),
 ];
 
+pub const MOON_PHASES: &[(&str, &str)] = &[
+    ("New Moon", "🌑"),
+    ("Waxing Crescent", "🌒"),
+    ("First Quarter", "🌓"),
+    ("Waxing Gibbous", "🌔"),
+    ("Full Moon", "🌕"),
+    ("Waning Gibbous", "🌖"),
+    ("Last Quarter", "🌗"),
+    ("Waning Crescent", "🌘"),
+];
+
+pub const MOON_PHASES_NERD: &[(&str, &str)] = &[
+    ("New Moon", "󰽤"),
+    ("Waxing Crescent", "󰽧"),
+    ("First Quarter", "󰽡"),
+    ("Waxing Gibbous", "󰽨"),
+    ("Full Moon", "󰽢"),
+    ("Waning Gibbous", "󰽦"),
+    ("Last Quarter", "󰽣"),
+    ("Waning Crescent", "󰽥"),
+];
 
 pub const ICON_PLACEHOLDER: &str = "{ICON}";

--- a/src/format.rs
+++ b/src/format.rs
@@ -2,8 +2,8 @@ use chrono::prelude::*;
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::constants::{ICON_PLACEHOLDER, MOON_PHASES, MOON_PHASES_NERD};
 use crate::lang::Lang;
-use crate::ICON_PLACEHOLDER;
 
 pub fn format_time(time: &str, ampm: bool) -> String {
     let hour = time.replace("00", "").parse::<i32>().unwrap();
@@ -68,6 +68,17 @@ pub fn format_ampm_time(day: &serde_json::Value, key: &str, ampm: bool) -> Strin
             .to_string()
     }
 }
+
+pub fn format_moon_phase_icon(phase: &str, nerd: bool) -> &str {
+    let fallback = if nerd { "󰽤" } else { "🌑" };
+    let table = if nerd { MOON_PHASES_NERD } else { MOON_PHASES };
+    table
+        .iter()
+        .find(|(name, _)| *name == phase)
+        .map(|(_, icon)| *icon)
+        .unwrap_or(fallback)
+}
+
 pub fn format_indicator(
     weather_conditions: &Value,
     area: &Value,
@@ -109,4 +120,51 @@ pub fn format_indicator(
         formatted_indicator = formatted_indicator.replace(ICON_PLACEHOLDER, weather_icon)
     }
     formatted_indicator
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_moon_phase_icon;
+
+    #[test]
+    fn maps_all_emoji_moon_phases() {
+        let cases = [
+            ("New Moon", "🌑"),
+            ("Waxing Crescent", "🌒"),
+            ("First Quarter", "🌓"),
+            ("Waxing Gibbous", "🌔"),
+            ("Full Moon", "🌕"),
+            ("Waning Gibbous", "🌖"),
+            ("Last Quarter", "🌗"),
+            ("Waning Crescent", "🌘"),
+        ];
+
+        for (phase, icon) in cases {
+            assert_eq!(format_moon_phase_icon(phase, false), icon);
+        }
+    }
+
+    #[test]
+    fn maps_all_nerd_moon_phases() {
+        let cases = [
+            ("New Moon", "󰽤"),
+            ("Waxing Crescent", "󰽧"),
+            ("First Quarter", "󰽡"),
+            ("Waxing Gibbous", "󰽨"),
+            ("Full Moon", "󰽢"),
+            ("Waning Gibbous", "󰽦"),
+            ("Last Quarter", "󰽣"),
+            ("Waning Crescent", "󰽥"),
+        ];
+
+        for (phase, icon) in cases {
+            assert_eq!(format_moon_phase_icon(phase, true), icon);
+        }
+    }
+
+    #[test]
+    fn falls_back_for_unknown_phase() {
+        assert_eq!(format_moon_phase_icon("Unknown", false), "🌑");
+        assert_eq!(format_moon_phase_icon("Unknown", true), "󰽤");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,17 @@ use std::process::exit;
 use std::thread;
 use std::time::{Duration, SystemTime};
 
-use chrono::{Locale, NaiveDate, NaiveTime, Local, Timelike};
+use chrono::{Local, Locale, NaiveDate, NaiveTime, Timelike};
 use clap::Parser;
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
 
 use crate::cli::Args;
-use crate::constants::{ICON_PLACEHOLDER, WEATHER_CODES, WEATHER_CODES_NERD};
-use crate::format::{format_ampm_time, format_chances, format_indicator, format_temp, format_time};
+use crate::constants::{WEATHER_CODES, WEATHER_CODES_NERD};
+use crate::format::{
+    format_ampm_time, format_chances, format_indicator, format_moon_phase_icon, format_temp,
+    format_time,
+};
 use crate::lang::Lang;
 
 mod cli;
@@ -170,11 +173,7 @@ fn main() {
         .filter(|part| !part.is_empty())
         .collect();
 
-    tooltip += &format!(
-        "{}: {}\n",
-        lang.location(),
-        location_parts.join(", ")
-    );
+    tooltip += &format!("{}: {}\n", lang.location(), location_parts.join(", "));
 
     if args.observation_time {
         if let Some(obs_time) = current_condition["observation_time"].as_str() {
@@ -209,7 +208,10 @@ fn main() {
         }
         let date = NaiveDate::parse_from_str(day["date"].as_str().unwrap(), "%Y-%m-%d").unwrap();
         let locale = Locale::try_from(lang.locale_str().as_str()).unwrap_or(Locale::en_US);
-        tooltip += &format!("{}</b>\n", date.format_localized(args.date_format.as_str(), locale));
+        tooltip += &format!(
+            "{}</b>\n",
+            date.format_localized(args.date_format.as_str(), locale)
+        );
 
         let (max_temp, min_temp) = if args.fahrenheit {
             (
@@ -231,12 +233,19 @@ fn main() {
             min_temp
         );
 
+        let moon_phase = day["astronomy"][0]["moon_phase"].as_str().unwrap_or("");
+        let moon_illumination = day["astronomy"][0]["moon_illumination"]
+            .as_str()
+            .unwrap_or("?");
+
         tooltip += &format!(
-            "{} {} {} {}\n",
+            "{} {} {} {} {} {}%\n",
             if args.nerd { "󰖜" } else { "🌅" },
             format_ampm_time(day, "sunrise", args.ampm),
             if args.nerd { "󰖛" } else { "🌇" },
-            format_ampm_time(day, "sunset", args.ampm)
+            format_ampm_time(day, "sunset", args.ampm),
+            format_moon_phase_icon(moon_phase, args.nerd),
+            moon_illumination
         );
 
         for hour in day["hourly"].as_array().unwrap() {


### PR DESCRIPTION
This PR adds moon phases next to the sunset and sunrise in the tooltip with illumination percentage.
wttr.in phase strings match English labels and don't require translation.

<img width="441" height="602" alt="screenshot-2026-02-20_01-17-25" src="https://github.com/user-attachments/assets/9e9ab77f-0ab1-478b-87d3-9ec21e909695" />

Nerd font mode
<img width="449" height="524" alt="screenshot-2026-02-21_17-19-34" src="https://github.com/user-attachments/assets/c316ca6a-4c64-4f11-9d03-e2d864af6e12" />

